### PR TITLE
Reload settings, segments autofill and add debug logs

### DIFF
--- a/OnlyUp!.asl
+++ b/OnlyUp!.asl
@@ -178,25 +178,27 @@ update
 		return false;
 	}
 
-	// If the number of enabled splits changes => reload splits and soft reset
-	if (vars.CountEnabledSplits() != vars.splits.Count)
-	{
-		vars.Log("reload enabled split settings");
-		vars.UpdateEnabledSplits();
-		if (settings["advanced"] && settings["enable_segments_autofill"])
-			vars.AutoFillSegments();
-		vars.softReset = true;
-		return false;
-	}
+	if (timer.CurrentPhase != TimerPhase.Ended) {
+		// If the number of enabled splits changes => reload splits and soft reset
+		if (vars.CountEnabledSplits() != vars.splits.Count)
+		{
+			vars.Log("reload enabled split settings");
+			vars.UpdateEnabledSplits();
+			if (settings["advanced"] && settings["enable_segments_autofill"])
+				vars.AutoFillSegments();
+			vars.softReset = true;
+			return false;
+		}
 
-	// Trigger autofill segments if settings is enabled
-	if (!vars.autoFillSegmentsLastValue && settings["advanced"] && settings["enable_segments_autofill"]) {
-		vars.AutoFillSegments();
-		vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
+		// Trigger autofill segments if settings is enabled
+		if (!vars.autoFillSegmentsLastValue && settings["advanced"] && settings["enable_segments_autofill"]) {
+			vars.AutoFillSegments();
+			vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
+		}
+		// Set autofill segments last value if settings is disabled
+		if (vars.autoFillSegmentsLastValue && !(settings["advanced"] && settings["enable_segments_autofill"]))
+			vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
 	}
-	// Set autofill segments value if settings is enabled
-	if (vars.autoFillSegmentsLastValue && !(settings["advanced"] && settings["enable_segments_autofill"]))
-		vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
 
 	if (current.coordX == 0 && current.coordY == 0 && current.coordZ == 0)
 	{

--- a/OnlyUp!.asl
+++ b/OnlyUp!.asl
@@ -49,9 +49,11 @@ startup
 		settings.Add(Segment.Key, false, Segment.Value);
 	};
 	settings.Add("advanced", false, "Advanced settings");
+	settings.SetToolTip("advanced", "Number of splits Segments in \"Edit Splits\" = (Number of splits checked in \"Autosplitter\") + 1");
 	settings.Add("disable_autosplitter", false, "Disable autosplitter", "advanced");
 	settings.Add("enable_debug_logs", false, "Enable debug logs", "advanced");
 	settings.Add("enable_segments_autofill", false, "Enable segments autofill", "advanced");
+	settings.SetToolTip("enable_segments_autofill", "WARNING Any of your current splits Segments in \"Edit Splits\" will be overwritten !\nIf you want to keep them do \"Save Splits As...\" before !");
 
 	refreshRate = 30;
 	vars.currSplit = 0;

--- a/OnlyUp!.asl
+++ b/OnlyUp!.asl
@@ -166,8 +166,8 @@ init
 		timer.CallRunManuallyModified();
 	};
 	vars.AutoFillSegments = AutoFillSegments;
-	vars.autoFillSegments = settings["advanced"] && settings["enable_segments_autofill"];
-	if (vars.autoFillSegments)
+	vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
+	if (vars.autoFillSegmentsLastValue)
 		vars.AutoFillSegments();
 }
 
@@ -190,10 +190,13 @@ update
 	}
 
 	// Trigger autofill segments if settings is enabled
-	if (!vars.autoFillSegments && settings["advanced"] && settings["enable_segments_autofill"]) {
+	if (!vars.autoFillSegmentsLastValue && settings["advanced"] && settings["enable_segments_autofill"]) {
 		vars.AutoFillSegments();
-		vars.autoFillSegments = settings["advanced"] && settings["enable_segments_autofill"];
+		vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
 	}
+	// Set autofill segments value if settings is enabled
+	if (vars.autoFillSegmentsLastValue && !(settings["advanced"] && settings["enable_segments_autofill"]))
+		vars.autoFillSegmentsLastValue = settings["advanced"] && settings["enable_segments_autofill"];
 
 	if (current.coordX == 0 && current.coordY == 0 && current.coordZ == 0)
 	{

--- a/OnlyUp!.asl
+++ b/OnlyUp!.asl
@@ -45,13 +45,13 @@ startup
 		{"split20","Space First Bumper"},
 	};
 
-	settings.Add("enable", true, "Enable autosplitter");
 	foreach(var Segment in vars.segmentsList) {
 		settings.Add(Segment.Key, false, Segment.Value);
 	};
-	settings.Add("advanced", true, "Advanced settings");
-	settings.Add("enable_debug_logs", true, "Enable debug logs", "advanced");
-	settings.Add("enableAutoFillSegments", false, "Enable segments autofill", "advanced");
+	settings.Add("advanced", false, "Advanced settings");
+	settings.Add("disable_autosplitter", false, "Disable autosplitter", "advanced");
+	settings.Add("enable_debug_logs", false, "Enable debug logs", "advanced");
+	settings.Add("enable_segments_autofill", false, "Enable segments autofill", "advanced");
 
 	refreshRate = 30;
 	vars.currSplit = 0;
@@ -166,16 +166,15 @@ init
 		timer.CallRunManuallyModified();
 	};
 	vars.AutoFillSegments = AutoFillSegments;
-	vars.autoFillSegments = settings["advanced"] && settings["enableAutoFillSegments"];
+	vars.autoFillSegments = settings["advanced"] && settings["enable_segments_autofill"];
 	if (vars.autoFillSegments)
 		vars.AutoFillSegments();
 }
 
 update
 {
-	// Enable/disable autosplitter script
-	if (!settings["enable"]) {
-		vars.Log("disable autosplitter script");
+	// Disable autosplitter script
+	if (settings["advanced"] && settings["disable_autosplitter"]) {
 		return false;
 	}
 
@@ -184,16 +183,16 @@ update
 	{
 		vars.Log("reload enabled split settings");
 		vars.UpdateEnabledSplits();
-		if (settings["advanced"] && settings["enableAutoFillSegments"])
+		if (settings["advanced"] && settings["enable_segments_autofill"])
 			vars.AutoFillSegments();
 		vars.softReset = true;
 		return false;
 	}
 
 	// Trigger autofill segments if settings is enabled
-	if (!vars.autoFillSegments && settings["advanced"] && settings["enableAutoFillSegments"]) {
+	if (!vars.autoFillSegments && settings["advanced"] && settings["enable_segments_autofill"]) {
 		vars.AutoFillSegments();
-		vars.autoFillSegments = settings["advanced"] && settings["enableAutoFillSegments"];
+		vars.autoFillSegments = settings["advanced"] && settings["enable_segments_autofill"];
 	}
 
 	if (current.coordX == 0 && current.coordY == 0 && current.coordZ == 0)


### PR DESCRIPTION
> **Note**
> - Reload settings -> allows you not to restart the game or LiveSplit when enabling or disabling split settings
> - Segments autofill setting -> when enabled it clears LiveSplit segments and automatically fills it with splits that are enabled in settings, when enabling or disabling split settings segments will be updated
> - Debug logs setting -> when enabled it prints logs that can be accessed with DebugViewer

> **Warning**
> - Segments autofill setting -> Any of your current segments will be overwritten, be careful to save your segments before enabling this setting if you want to keep them!